### PR TITLE
MLflow support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ This component performs the following operations:
 #### 4. Metrics ([code](./src/metrics.py))
 This component is passed the mlpipelinemetrics which contains metrics and generates a visualization of them that the kubeflow UI can understand.
 
+##### MLflow
+
+This branch supports MLflow tracking so you can watch long-running training metrics live. To install MLflow on your SAME cluster, install Terraform and ensure that either your `KUBECONFIG` environment variable or your `~/.kube/config` file points to the same cluster you ran `same init` on, then run:
+
+```
+git clone https://github.com/combinator-ml/terraform-k8s-mlflow
+cd terraform-k8s-mlflow
+terraform init
+terraform apply
+```
+
+Then run:
+```
+kubectl port-forward service/mlflow -n mlflow 5000:5000
+```
+And open [http://localhost:5000](http://localhost:5000).
+
 ## Developing
 
 When attempting to run or test the code locally you will need to install the reqiured libraries (this requires [poetry](https://python-poetry.org)).

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,13 +1,23 @@
 from kfp import components
 from kfp import dsl
 
+from kubernetes.client.models import V1EnvVar
 
 @dsl.pipeline(
     name="Cross-selling training pipeline",
     description="",
 )
 def pipeline(
-    epochs: int = 10,
+    # Lots of epochs highlights the value of a streaming metrics system like
+    # mlflow
+    epochs: int = 1000,
+    # TODO find a less ugly way to sneak these in (same CLI can do this for us?
+    # WITH METAPROGRAMMING?) - or, actually, just using these defaults are
+    # probably fine
+    AWS_ACCESS_KEY_ID: str = "minio",
+    AWS_SECRET_ACCESS_KEY: str = "minio123",
+    MLFLOW_S3_ENDPOINT_URL: str = "http://minio.mlflow.svc.cluster.local:9000",
+    MLFLOW_TRACKING_URI: str = "http://mlflow.mlflow.svc.cluster.local:5000",
 ):
     import download
     import metrics
@@ -25,10 +35,19 @@ def pipeline(
         preprocessing.preprocess, base_image=BASE_IMAGE
     )(downloadOp.output)
 
-    trainOp = components.func_to_container_op(training.train, base_image=BASE_IMAGE)(
+
+    trainOp = components.func_to_container_op(
+        training.train, base_image=BASE_IMAGE,
+        packages_to_install=["mlflow==1.17.0", "boto3==1.17.79"],
+    )(
         preprocessOp.output,
         n_epochs=epochs,
     )
+    for (k, v) in [("AWS_ACCESS_KEY_ID", AWS_ACCESS_KEY_ID),
+                   ("AWS_SECRET_ACCESS_KEY", AWS_SECRET_ACCESS_KEY),
+                   ("MLFLOW_S3_ENDPOINT_URL", MLFLOW_S3_ENDPOINT_URL),
+                   ("MLFLOW_TRACKING_URI", MLFLOW_TRACKING_URI)]:
+        trainOp = trainOp.add_env_variable(V1EnvVar(name=k, value=v))
 
     components.func_to_container_op(metrics.produce_metrics, base_image=BASE_IMAGE)(
         preprocessOp.output, trainOp.output

--- a/src/training.py
+++ b/src/training.py
@@ -13,6 +13,9 @@ def train(
     import pandas as pd
     import tensorflow as tf
 
+    import mlflow
+    mlflow.autolog()
+
     from tensorflow import keras
 
     file = "train.csv"
@@ -73,4 +76,5 @@ def train(
     #     )
 
     # Save the model to the designated dir
+    print("Saving model to", model_dir)
     model.save(model_dir)


### PR DESCRIPTION
This PR is intended to highlight the diff in the UX that would be required to add MLflow support to a specific pipeline.

Rather than merging this diff, I propose that we instead use it to inform changes to the SAME CLI to automate doing the steps described in the README and the user code, instead behind some flag, like:

```
$ same addon mlflow enable
Installing mlflow... [does terraform apply behind the scenes]
Noting mlflow add-on in ~/.same/config.json
SAME pipelines will be now be automatically instrumented with MLflow
To access mlflow, run:
    kubectl port-forward service/mlflow -n mlflow 5000:5000
And open http://localhost:5000 in your browser
```